### PR TITLE
Update copyright year from 2024 to 2026

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -1,4 +1,4 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Sphinx configuration for ArchML documentation."""

--- a/src/archml/__init__.py
+++ b/src/archml/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """ArchML — a text-based DSL for defining software architecture alongside code."""

--- a/src/archml/cli/__init__.py
+++ b/src/archml/cli/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Command-line interface for ArchML."""

--- a/src/archml/cli/main.py
+++ b/src/archml/cli/main.py
@@ -1,4 +1,4 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Entry point for the ArchML command-line interface."""

--- a/src/archml/lsp/__init__.py
+++ b/src/archml/lsp/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Language server (LSP) implementation for .archml files."""

--- a/src/archml/model/__init__.py
+++ b/src/archml/model/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Semantic model for ArchML (systems, components, interfaces, etc.)."""

--- a/src/archml/parser/__init__.py
+++ b/src/archml/parser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Lexer and parser for .archml files."""

--- a/src/archml/sphinx_ext/__init__.py
+++ b/src/archml/sphinx_ext/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Sphinx extension for embedding ArchML architecture views."""

--- a/src/archml/validation/__init__.py
+++ b/src/archml/validation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Consistency checks for ArchML models (dangling refs, unused interfaces, etc.)."""

--- a/src/archml/views/__init__.py
+++ b/src/archml/views/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """View generation and rendering for ArchML models."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,4 +1,4 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the ArchML CLI entry point."""

--- a/tests/lsp/__init__.py
+++ b/tests/lsp/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/model/__init__.py
+++ b/tests/model/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/parser/__init__.py
+++ b/tests/parser/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/sphinx_ext/__init__.py
+++ b/tests/sphinx_ext/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/validation/__init__.py
+++ b/tests/validation/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/views/__init__.py
+++ b/tests/views/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2024 ArchML Contributors
+# Copyright 2026 ArchML Contributors
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Summary
This pull request updates the copyright year in all source files and test files from 2024 to 2026 to reflect the current year.

## Changes
- Updated copyright headers across all Python modules in the `src/archml/` package:
  - Core package (`__init__.py`)
  - CLI module (`cli/`)
  - LSP module (`lsp/`)
  - Model module (`model/`)
  - Parser module (`parser/`)
  - Sphinx extension module (`sphinx_ext/`)
  - Validation module (`validation/`)
  - Views module (`views/`)
- Updated copyright headers in all test modules under `tests/`
- Updated copyright header in Sphinx documentation configuration

## Details
This is a routine maintenance update to keep copyright notices current. All changes are limited to the copyright year in the SPDX license headers at the top of each file.

https://claude.ai/code/session_01Et6S1nvm9W9c6gu9pEqMeb