### PR TITLE
feat: implement init command with name, workspace-dir, and YAML config

### DIFF
--- a/src/archml/cli/main.py
+++ b/src/archml/cli/main.py
@@ -121,10 +121,7 @@ def _cmd_init(args: argparse.Namespace) -> int:
         return 1
 
     workspace_yaml.write_text(
-        f"build-directory: {_DEFAULT_BUILD_DIR}\n"
-        "source-imports:\n"
-        f"  - name: {name}\n"
-        "    local-path: .\n",
+        f"build-directory: {_DEFAULT_BUILD_DIR}\nsource-imports:\n  - name: {name}\n    local-path: .\n",
         encoding="utf-8",
     )
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -36,9 +36,7 @@ def test_init_creates_workspace_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert (tmp_path / ".archml-workspace.yaml").exists()
 
 
-def test_init_workspace_yaml_has_correct_content(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_init_workspace_yaml_has_correct_content(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """init writes source-import mapping with the given mnemonic into the YAML config."""
     monkeypatch.setattr(sys, "argv", ["archml", "init", "myrepo", str(tmp_path)])
     with pytest.raises(SystemExit) as exc_info:


### PR DESCRIPTION
Implements the new `archml init` behavior as described in #38:

- Takes `<name>` and `<workspace-dir>` as required positional arguments
- Creates `<workspace-dir>` if it does not exist
- Fails if `.archml-workspace.yaml` already present
- Creates `.archml-workspace.yaml` with source-imports entry mapping mnemonic to `.`
- Validates that mnemonic name is non-empty

Closes #38

Generated with [Claude Code](https://claude.ai/code)